### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for the Open Library API that enables AI assistants to search for book information.
 
+<a href="https://glama.ai/mcp/servers/@8enSmith/mcp-open-library">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@8enSmith/mcp-open-library/badge" alt="mcp-open-library MCP server" />
+</a>
+
 ## Overview
 
 This project implements an MCP server that provides a tool for AI assistants to search the [Open Library](https://openlibrary.org/) for book information by title. The server returns structured data about the most relevant book match, including title, authors, publication year, and other metadata.


### PR DESCRIPTION
This PR adds a badge for the [mcp-open-library](https://glama.ai/mcp/servers/@8enSmith/mcp-open-library) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@8enSmith/mcp-open-library">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@8enSmith/mcp-open-library/badge" alt="mcp-open-library MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.