### PR TITLE
Add MCP Find badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/8enSmith/mcp-open-library)](https://archestra.ai/mcp-catalog/8ensmith__mcp-open-library)
 [![smithery badge](https://smithery.ai/badge/@8enSmith/mcp-open-library)](https://smithery.ai/server/@8enSmith/mcp-open-library)
-
+[![Listed on MCP Find](https://img.shields.io/badge/MCP_Find-Listed-blue)](https://mcp-find.org/tools/fastmcp)
 A Model Context Protocol (MCP) server for the Open Library API that enables AI assistants to search for book and author information.
 
 <a href="https://glama.ai/mcp/servers/@8enSmith/mcp-open-library">


### PR DESCRIPTION
Hi 👋

fastmcp is featured on [MCP Find](https://mcp-find.org/tools/fastmcp), 
a curated directory for the MCP ecosystem. The listing includes an 
editorial review, evidence profile, trust signals, and related 
tool comparisons.

This PR adds a small badge linking to the listing page.

**What MCP Find provides for fastmcp:**
- Dedicated tool profile with editorial review
- Trust/risk signal assessment  
- Comparison pages with related tools
- Integration into topic hubs (Coding cluster)
- Related workflow and learning guide links

Feel free to merge, modify placement, or close if you'd prefer 
not to include it. No pressure at all!

Preview: [fastmcp on MCP Find](https://mcp-find.org/tools/discogs-mcp-server)