### PR TITLE
feat: publish to the official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -40,6 +40,28 @@ jobs:
       - name: Assert release metadata is consistent
         run: node scripts/assert-release-consistency.mjs "${GITHUB_REF_NAME}"
 
+      # mcp-publisher release version. Bump periodically; see
+      # https://github.com/modelcontextprotocol/registry/releases
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+        run: |
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          ASSET="mcp-publisher_${OS}_${ARCH}.tar.gz"
+          CHECKSUMS="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+
+          curl -sL -O "${BASE_URL}/${ASSET}"
+          curl -sL -O "${BASE_URL}/${CHECKSUMS}"
+
+          grep " ${ASSET}\$" "${CHECKSUMS}" | sha256sum --check --ignore-missing
+
+          tar xzf "${ASSET}" mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
       - name: Publish package to npm
         run: |
           VERSION="$(node -p "require('./package.json').version")"
@@ -62,13 +84,6 @@ jobs:
           done
           echo "Timed out waiting for mcp-open-library@${VERSION} to appear on npm." >&2
           exit 1
-
-      - name: Install mcp-publisher
-        run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
-
-      - name: Validate server.json
-        run: ./mcp-publisher validate
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,77 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # npm trusted publishing AND mcp-publisher OIDC
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:precommit
+
+      - name: Build
+        run: npm run build
+
+      - name: Assert release metadata is consistent
+        run: node scripts/assert-release-consistency.mjs "${GITHUB_REF_NAME}"
+
+      - name: Publish package to npm
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "mcp-open-library@${VERSION}" version >/dev/null 2>&1; then
+            echo "mcp-open-library@${VERSION} is already on npm, skipping publish."
+          else
+            npm publish
+          fi
+
+      - name: Wait for npm to serve the new version
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          for attempt in $(seq 1 12); do
+            if npm view "mcp-open-library@${VERSION}" version >/dev/null 2>&1; then
+              echo "mcp-open-library@${VERSION} is visible on npm."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/12: not visible yet, retrying in 5s..."
+            sleep 5
+          done
+          echo "Timed out waiting for mcp-open-library@${VERSION} to appear on npm." >&2
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -46,16 +46,20 @@ jobs:
         env:
           MCP_PUBLISHER_VERSION: v1.8.1
         run: |
+          # The default run: shell is `bash -e`, which does NOT set pipefail —
+          # set it explicitly so a failed grep cannot feed empty input forward.
+          set -euo pipefail
+
           OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
           ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
           ASSET="mcp-publisher_${OS}_${ARCH}.tar.gz"
           CHECKSUMS="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
           BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
 
-          curl -sL -O "${BASE_URL}/${ASSET}"
-          curl -sL -O "${BASE_URL}/${CHECKSUMS}"
+          curl --fail --silent --show-error --location -O "${BASE_URL}/${ASSET}"
+          curl --fail --silent --show-error --location -O "${BASE_URL}/${CHECKSUMS}"
 
-          grep " ${ASSET}\$" "${CHECKSUMS}" | sha256sum --check --ignore-missing
+          awk -v asset="${ASSET}" '$2 == asset' "${CHECKSUMS}" | sha256sum --check --strict
 
           tar xzf "${ASSET}" mcp-publisher
 

--- a/.github/workflows/validate-server-json.yml
+++ b/.github/workflows/validate-server-json.yml
@@ -32,9 +32,24 @@ jobs:
       - name: Assert release metadata is consistent
         run: node scripts/assert-release-consistency.mjs
 
+      # mcp-publisher release version. Bump periodically; see
+      # https://github.com/modelcontextprotocol/registry/releases
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          ASSET="mcp-publisher_${OS}_${ARCH}.tar.gz"
+          CHECKSUMS="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
+          BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
+
+          curl -sL -O "${BASE_URL}/${ASSET}"
+          curl -sL -O "${BASE_URL}/${CHECKSUMS}"
+
+          grep " ${ASSET}\$" "${CHECKSUMS}" | sha256sum --check --ignore-missing
+
+          tar xzf "${ASSET}" mcp-publisher
 
       - name: Validate server.json
         run: ./mcp-publisher validate

--- a/.github/workflows/validate-server-json.yml
+++ b/.github/workflows/validate-server-json.yml
@@ -39,16 +39,20 @@ jobs:
         env:
           MCP_PUBLISHER_VERSION: v1.8.1
         run: |
+          # The default run: shell is `bash -e`, which does NOT set pipefail —
+          # set it explicitly so a failed grep cannot feed empty input forward.
+          set -euo pipefail
+
           OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
           ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
           ASSET="mcp-publisher_${OS}_${ARCH}.tar.gz"
           CHECKSUMS="registry_${MCP_PUBLISHER_VERSION#v}_checksums.txt"
           BASE_URL="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}"
 
-          curl -sL -O "${BASE_URL}/${ASSET}"
-          curl -sL -O "${BASE_URL}/${CHECKSUMS}"
+          curl --fail --silent --show-error --location -O "${BASE_URL}/${ASSET}"
+          curl --fail --silent --show-error --location -O "${BASE_URL}/${CHECKSUMS}"
 
-          grep " ${ASSET}\$" "${CHECKSUMS}" | sha256sum --check --ignore-missing
+          awk -v asset="${ASSET}" '$2 == asset' "${CHECKSUMS}" | sha256sum --check --strict
 
           tar xzf "${ASSET}" mcp-publisher
 

--- a/.github/workflows/validate-server-json.yml
+++ b/.github/workflows/validate-server-json.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - server.json
       - package.json
+      - CHANGELOG.md
       - scripts/**
       - .github/workflows/validate-server-json.yml
 

--- a/.github/workflows/validate-server-json.yml
+++ b/.github/workflows/validate-server-json.yml
@@ -1,0 +1,40 @@
+name: Validate server.json
+
+on:
+  pull_request:
+    paths:
+      - server.json
+      - package.json
+      - scripts/**
+      - .github/workflows/validate-server-json.yml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:precommit
+
+      - name: Assert release metadata is consistent
+        run: node scripts/assert-release-consistency.mjs
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Published to the official MCP Registry as `io.github.8ensmith/mcp-open-library`
+- Automated release pipeline: version tags publish to npm and the MCP Registry over OIDC
+
+### Fixed
+- Server now reports its real package version instead of a hardcoded `1.0.0`
+
+## [1.0.2] - 2026-02-04
+### Changed
+- Updated dependencies
+
 ## [1.0.1] - 2026-02-04
 ### Changed
 - Updated @modelcontextprotocol/sdk to v1.25.3 ([#30](https://github.com/8enSmith/mcp-open-library/pull/30))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Published to the official MCP Registry as `io.github.8ensmith/mcp-open-library`
+- Published to the official MCP Registry as `io.github.8enSmith/mcp-open-library`
 - Automated release pipeline: version tags publish to npm and the MCP Registry over OIDC
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ This project implements an MCP server that provides tools for AI assistants to i
 
 ## Installation
 
+### MCP Registry
+
+This server is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) as
+`io.github.8ensmith/mcp-open-library`. Clients that support the registry can install it by that name.
+
+To inspect the published listing:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+```
+
 ### Installing via Smithery
 
 To install MCP Open Library for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@8enSmith/mcp-open-library):

--- a/README.md
+++ b/README.md
@@ -275,6 +275,37 @@ npm run inspector http://localhost:8080
 npm test
 ```
 
+### Releasing
+
+Releases are automated. Pushing a `v*` tag triggers
+[`publish-mcp.yml`](.github/workflows/publish-mcp.yml), which runs the checks, publishes the package
+to npm, and then registers the new version with the MCP Registry. Both npm and the registry
+authenticate over GitHub OIDC, so there are no publishing secrets to manage.
+
+`package.json`'s `version` is the single source of truth. `npm version` derives everything else from
+it via a `version` lifecycle hook, so a release is one command:
+
+```bash
+npm version patch   # or minor / major
+git push --follow-tags
+```
+
+That single command bumps `package.json`, rewrites `server.json` to match, promotes the changelog's
+`## [Unreleased]` heading to the new version and today's date, and commits the lot under one tag.
+
+Two things to know before you run it:
+
+- **Write your changelog entries first.** They go under a `## [Unreleased]` heading in
+  [`CHANGELOG.md`](CHANGELOG.md) as you merge work. `npm version` fails if that heading is missing,
+  rather than releasing something undocumented. If it does fail, undo the partial bump with
+  `git restore --source=HEAD --staged --worktree package.json package-lock.json server.json`.
+- **The working tree must be clean**, and the pre-commit hook (lint + full test suite) runs inside
+  `npm version`.
+
+CI re-asserts that the tag, `package.json`, `server.json` and `CHANGELOG.md` all agree before
+anything is published — see `scripts/assert-release-consistency.mjs`. The same check runs on pull
+requests that touch those files.
+
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a pull request.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ This project implements an MCP server that provides tools for AI assistants to i
 
 ### MCP Registry
 
-This server is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) as
-`io.github.8ensmith/mcp-open-library`. Clients that support the registry can install it by that name.
+This server publishes to the official MCP Registry as
+`io.github.8ensmith/mcp-open-library` from v1.0.3 onwards. Clients that
+support the registry can install it by that name.
 
 To inspect the published listing:
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ This project implements an MCP server that provides tools for AI assistants to i
 ### MCP Registry
 
 This server publishes to the official MCP Registry as
-`io.github.8ensmith/mcp-open-library` from v1.0.3 onwards. Clients that
+`io.github.8enSmith/mcp-open-library` from v1.0.3 onwards. Clients that
 support the registry can install it by that name.
 
 To inspect the published listing:
 
 ```bash
-curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8enSmith/mcp-open-library"
 ```
 
 ### Installing via Smithery

--- a/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
+++ b/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** List `mcp-open-library` in the official MCP Registry as `io.github.8ensmith/mcp-open-library`, published by a secretless, tag-triggered pipeline that releases to npm and the registry together.
+**Goal:** List `mcp-open-library` in the official MCP Registry as `io.github.8enSmith/mcp-open-library`, published by a secretless, tag-triggered pipeline that releases to npm and the registry together.
 
 **Architecture:** `package.json` `version` is the single source of truth. An `npm version` lifecycle hook derives `server.json` from it; `src/index.ts` reads it at runtime; CI asserts every copy agrees before publishing anything. Both npm and the MCP registry authenticate over GitHub OIDC, so no credential is ever stored.
 
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- Server name is **`io.github.8ensmith/mcp-open-library`** — lowercase, permanent, must be byte-identical in `server.json` `name` and `package.json` `mcpName`.
+- Server name is **`io.github.8enSmith/mcp-open-library`** — permanent, must be byte-identical in `server.json` `name` and `package.json` `mcpName`. **The capital `S` is required.** The registry grants `io.github.<owner>/*` from GitHub's login verbatim and matches it with a case-sensitive `strings.HasPrefix` (`internal/auth/jwt.go:165-173`), so a lowercased name is rejected at publish time.
 - npm package name is **`mcp-open-library`**; it must equal `server.json` `packages[0].identifier`.
 - `server.json` `description` is capped at **100 characters** by the schema.
 - Schema URI is **`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`**.
@@ -55,11 +55,11 @@ import { checkReleaseConsistency } from "./assert-release-consistency.mjs";
 const pkg = {
   name: "mcp-open-library",
   version: "1.0.3",
-  mcpName: "io.github.8ensmith/mcp-open-library",
+  mcpName: "io.github.8enSmith/mcp-open-library",
 };
 
 const server = {
-  name: "io.github.8ensmith/mcp-open-library",
+  name: "io.github.8enSmith/mcp-open-library",
   version: "1.0.3",
   packages: [{ identifier: "mcp-open-library", version: "1.0.3" }],
 };
@@ -122,7 +122,7 @@ describe("checkReleaseConsistency", () => {
   it("reports a name/mcpName mismatch", () => {
     const problems = checkReleaseConsistency({
       pkg,
-      server: { ...server, name: "io.github.8ensmith/wrong-name" },
+      server: { ...server, name: "io.github.8enSmith/wrong-name" },
       tag: "v1.0.3",
     });
     expect(problems).toHaveLength(1);
@@ -143,7 +143,7 @@ describe("checkReleaseConsistency", () => {
     const problems = checkReleaseConsistency({
       pkg,
       server: {
-        name: "io.github.8ensmith/wrong-name",
+        name: "io.github.8enSmith/wrong-name",
         version: "1.0.1",
         packages: [{ identifier: "wrong-package", version: "1.0.2" }],
       },
@@ -269,7 +269,7 @@ Note the version is `1.0.2`, matching today's `package.json`. See Global Constra
 ```json
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.8ensmith/mcp-open-library",
+  "name": "io.github.8enSmith/mcp-open-library",
   "title": "Open Library",
   "description": "Search books and authors on the Internet Archive's Open Library",
   "version": "1.0.2",
@@ -294,7 +294,7 @@ Note the version is `1.0.2`, matching today's `package.json`. See Global Constra
 Insert immediately after the `"description"` line (`package.json:4`):
 
 ```json
-  "mcpName": "io.github.8ensmith/mcp-open-library",
+  "mcpName": "io.github.8enSmith/mcp-open-library",
 ```
 
 - [ ] **Step 3: Run the consistency checker against the real files**
@@ -342,7 +342,7 @@ import { describe, it, expect } from "vitest";
 
 import { syncServerJson } from "./sync-server-json.mjs";
 
-const mcpName = "io.github.8ensmith/mcp-open-library";
+const mcpName = "io.github.8enSmith/mcp-open-library";
 const packageName = "mcp-open-library";
 
 function makeServer() {
@@ -434,7 +434,7 @@ describe("syncServerJson", () => {
     expect(() =>
       syncServerJson(makeServer(), {
         version: "1.0.3",
-        mcpName: "io.github.8ensmith/something-else",
+        mcpName: "io.github.8enSmith/something-else",
         packageName,
       }),
     ).toThrow(/does not match/);
@@ -848,12 +848,12 @@ Insert directly under the `## Installation` heading, above `### Installing via S
 ### MCP Registry
 
 This server is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) as
-`io.github.8ensmith/mcp-open-library`. Clients that support the registry can install it by that name.
+`io.github.8enSmith/mcp-open-library`. Clients that support the registry can install it by that name.
 
 To inspect the published listing:
 
 ```bash
-curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8enSmith/mcp-open-library"
 ```
 ````
 
@@ -864,7 +864,7 @@ The file currently jumps from `1.0.1` straight back to `1.0.0` — the released 
 ```markdown
 ## [Unreleased]
 ### Added
-- Published to the official MCP Registry as `io.github.8ensmith/mcp-open-library`
+- Published to the official MCP Registry as `io.github.8enSmith/mcp-open-library`
 - Automated release pipeline: version tags publish to npm and the MCP Registry over OIDC
 
 ### Fixed
@@ -911,7 +911,7 @@ These steps are **not** part of the implementation and must not be run by an imp
    node -e "const t=require(require('os').homedir()+'/.config/mcp-publisher/token.json').token; console.log(JSON.parse(Buffer.from(t.split('.')[1],'base64url')))"
    ```
 
-   Expected: a permissions claim covering `io.github.8ensmith/*`. If it shows a different case, correct `server.json` `name` and `package.json` `mcpName` together before releasing.
+   Expected: a permissions claim covering `io.github.8enSmith/*` — note the capital `S`. This was run on 2026-08-09 and confirmed exactly that, overturning the original lowercase assumption. If it ever shows a different case, correct `server.json` `name` and `package.json` `mcpName` together before releasing.
 
 4. **Promote the changelog.** Rename `## [Unreleased]` to `## [1.0.3] - <today>`.
 
@@ -926,9 +926,9 @@ These steps are **not** part of the implementation and must not be run by an imp
 
    ```bash
    npm view mcp-open-library@1.0.3 mcpName
-   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8enSmith/mcp-open-library"
    ```
 
-   The first must print `io.github.8ensmith/mcp-open-library`; the second must return the listing.
+   The first must print `io.github.8enSmith/mcp-open-library`; the second must return the listing.
 
 If the registry step fails after npm succeeded, fix the cause and re-run the workflow from the Actions tab. The npm step self-skips, so the re-run picks up where it failed.

--- a/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
+++ b/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
@@ -1,0 +1,934 @@
+# Publish to MCP Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** List `mcp-open-library` in the official MCP Registry as `io.github.8ensmith/mcp-open-library`, published by a secretless, tag-triggered pipeline that releases to npm and the registry together.
+
+**Architecture:** `package.json` `version` is the single source of truth. An `npm version` lifecycle hook derives `server.json` from it; `src/index.ts` reads it at runtime; CI asserts every copy agrees before publishing anything. Both npm and the MCP registry authenticate over GitHub OIDC, so no credential is ever stored.
+
+**Tech Stack:** Node 22 (ESM), TypeScript, vitest, GitHub Actions, `mcp-publisher` CLI, npm trusted publishing.
+
+**Spec:** `docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md`
+
+## Global Constraints
+
+- Server name is **`io.github.8ensmith/mcp-open-library`** — lowercase, permanent, must be byte-identical in `server.json` `name` and `package.json` `mcpName`.
+- npm package name is **`mcp-open-library`**; it must equal `server.json` `packages[0].identifier`.
+- `server.json` `description` is capped at **100 characters** by the schema.
+- Schema URI is **`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`**.
+- CI must run **`npm run test:precommit`**, never `npm test` — the latter is bare `vitest` (watch mode) and will hang the runner until the job times out.
+- npm trusted publishing requires **npm ≥ 11.5.1** and **Node ≥ 22.14.0**. `.nvmrc` pins v22.21.1, but Node 22 ships npm 10.x, so CI must run `npm install -g npm@latest`.
+- Workflows that publish need **`id-token: write`** — one permission covers both npm OIDC and `mcp-publisher login github-oidc`.
+- **`server.json` is committed at version `1.0.2`, matching today's `package.json`.** The spec shows `1.0.3` because that is what ships; the bump to `1.0.3` happens later via `npm version patch`. Committing `1.0.3` now would make the Task 1 checker fail on every PR.
+- New scripts are plain `.mjs`, not TypeScript. The `version` hook must run before any build step exists, so these files cannot depend on `tsc` output.
+- Scripts follow the existing direct-invocation idiom from `src/index.ts:75`: `if (process.argv[1] === new URL(import.meta.url).pathname)`.
+- ESLint enforces `import/order` with `newlines-between: always`. `node:` builtins go in the first group, followed by a blank line.
+- Conventional commits (the repo uses commitizen).
+
+---
+
+### Task 1: Release-consistency checker
+
+The invariant everything else depends on. Written first so Task 2 has something to verify it with.
+
+**Files:**
+
+- Create: `scripts/assert-release-consistency.mjs`
+- Test: `scripts/assert-release-consistency.test.mjs`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `checkReleaseConsistency({ pkg, server, tag }) => string[]` — returns an array of human-readable problem descriptions, empty when consistent. `tag` is optional; when `undefined` the tag check is skipped. Tasks 5 and 6 invoke the file as a CLI.
+
+Vitest has no config file in this repo, so it uses default `include` globs — `scripts/*.test.mjs` is picked up automatically with no wiring.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/assert-release-consistency.test.mjs`:
+
+```js
+import { describe, it, expect } from "vitest";
+
+import { checkReleaseConsistency } from "./assert-release-consistency.mjs";
+
+const pkg = {
+  name: "mcp-open-library",
+  version: "1.0.3",
+  mcpName: "io.github.8ensmith/mcp-open-library",
+};
+
+const server = {
+  name: "io.github.8ensmith/mcp-open-library",
+  version: "1.0.3",
+  packages: [{ identifier: "mcp-open-library", version: "1.0.3" }],
+};
+
+describe("checkReleaseConsistency", () => {
+  it("returns no problems when everything agrees", () => {
+    expect(checkReleaseConsistency({ pkg, server, tag: "v1.0.3" })).toEqual([]);
+  });
+
+  it("skips the tag check when no tag is supplied", () => {
+    expect(checkReleaseConsistency({ pkg, server })).toEqual([]);
+  });
+
+  it("accepts a tag without the v prefix", () => {
+    expect(checkReleaseConsistency({ pkg, server, tag: "1.0.3" })).toEqual([]);
+  });
+
+  it("reports a tag that does not match package.json", () => {
+    const problems = checkReleaseConsistency({ pkg, server, tag: "v9.9.9" });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("git tag");
+  });
+
+  it("reports a server.json version mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: { ...server, version: "1.0.2" },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("server.json version");
+  });
+
+  it("reports a packages[0].version mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: {
+        ...server,
+        packages: [{ identifier: "mcp-open-library", version: "1.0.2" }],
+      },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("packages[0].version");
+  });
+
+  it("reports a packages[0].identifier mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: {
+        ...server,
+        packages: [{ identifier: "wrong-package", version: "1.0.3" }],
+      },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("packages[0].identifier");
+  });
+
+  it("reports a name/mcpName mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: { ...server, name: "io.github.8ensmith/wrong-name" },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("mcpName");
+  });
+
+  it("reports a missing packages entry", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: { ...server, packages: [] },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("packages[0]");
+  });
+
+  it("reports every problem at once rather than stopping at the first", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: {
+        name: "io.github.8ensmith/wrong-name",
+        version: "1.0.1",
+        packages: [{ identifier: "wrong-package", version: "1.0.2" }],
+      },
+      tag: "v9.9.9",
+    });
+    expect(problems).toHaveLength(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run scripts/assert-release-consistency.test.mjs`
+Expected: FAIL — cannot resolve `./assert-release-consistency.mjs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/assert-release-consistency.mjs`:
+
+```js
+import { readFileSync } from "node:fs";
+
+export function checkReleaseConsistency({ pkg, server, tag }) {
+  const problems = [];
+  const version = pkg.version;
+
+  if (tag !== undefined) {
+    const tagVersion = tag.startsWith("v") ? tag.slice(1) : tag;
+    if (tagVersion !== version) {
+      problems.push(
+        `git tag "${tag}" does not match package.json version "${version}"`,
+      );
+    }
+  }
+
+  if (server.version !== version) {
+    problems.push(
+      `server.json version "${server.version}" does not match package.json version "${version}"`,
+    );
+  }
+
+  const entry = server.packages?.[0];
+
+  if (!entry) {
+    problems.push("server.json has no packages[0] entry");
+  } else {
+    if (entry.version !== version) {
+      problems.push(
+        `server.json packages[0].version "${entry.version}" does not match package.json version "${version}"`,
+      );
+    }
+    if (entry.identifier !== pkg.name) {
+      problems.push(
+        `server.json packages[0].identifier "${entry.identifier}" does not match package.json name "${pkg.name}"`,
+      );
+    }
+  }
+
+  if (server.name !== pkg.mcpName) {
+    problems.push(
+      `server.json name "${server.name}" does not match package.json mcpName "${pkg.mcpName}"`,
+    );
+  }
+
+  return problems;
+}
+
+function readJson(relativePath) {
+  return JSON.parse(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+  );
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const problems = checkReleaseConsistency({
+    pkg: readJson("../package.json"),
+    server: readJson("../server.json"),
+    tag: process.argv[2],
+  });
+
+  if (problems.length > 0) {
+    console.error("Release metadata is inconsistent:");
+    for (const problem of problems) {
+      console.error(`  - ${problem}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Release metadata is consistent.");
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run scripts/assert-release-consistency.test.mjs`
+Expected: PASS — 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/assert-release-consistency.mjs scripts/assert-release-consistency.test.mjs
+git commit -m "feat: add release metadata consistency checker"
+```
+
+---
+
+### Task 2: Add `server.json` and `mcpName`
+
+**Files:**
+
+- Create: `server.json`
+- Modify: `package.json` (add `mcpName` after `description`)
+
+**Interfaces:**
+
+- Consumes: the Task 1 CLI, used here as the acceptance test.
+- Produces: `server.json` at the repo root — Tasks 3, 5 and 6 all read it.
+
+Note the version is `1.0.2`, matching today's `package.json`. See Global Constraints.
+
+- [ ] **Step 1: Create `server.json`**
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.8ensmith/mcp-open-library",
+  "title": "Open Library",
+  "description": "Search books and authors on the Internet Archive's Open Library",
+  "version": "1.0.2",
+  "websiteUrl": "https://github.com/8enSmith/mcp-open-library#readme",
+  "repository": {
+    "url": "https://github.com/8enSmith/mcp-open-library",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "mcp-open-library",
+      "version": "1.0.2",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Add `mcpName` to `package.json`**
+
+Insert immediately after the `"description"` line (`package.json:4`):
+
+```json
+  "mcpName": "io.github.8ensmith/mcp-open-library",
+```
+
+- [ ] **Step 3: Run the consistency checker against the real files**
+
+Run: `node scripts/assert-release-consistency.mjs`
+Expected: `Release metadata is consistent.` and exit code 0.
+
+- [ ] **Step 4: Verify the checker actually fails on a bad tag**
+
+Run: `node scripts/assert-release-consistency.mjs v9.9.9`
+Expected: exit code 1, and output containing `git tag "v9.9.9" does not match package.json version "1.0.2"`.
+
+This confirms the CLI wiring works, not just the pure function.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server.json package.json
+git commit -m "feat: add server.json and mcpName for MCP registry listing"
+```
+
+---
+
+### Task 3: Version-sync script and `npm version` hook
+
+**Files:**
+
+- Create: `scripts/sync-server-json.mjs`
+- Test: `scripts/sync-server-json.test.mjs`
+- Modify: `package.json` (add `version` lifecycle script)
+
+**Interfaces:**
+
+- Consumes: `server.json` from Task 2.
+- Produces: `syncServerJson(server, { version, mcpName, packageName }) => object` — returns a new object; never mutates its input. Throws when `server.name !== mcpName`.
+
+`packageName` scopes the version bump to the entry for *this* npm package, leaving any future entry for another registry alone. With one package today the behaviour is identical, but it makes the contract explicit.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/sync-server-json.test.mjs`:
+
+```js
+import { describe, it, expect } from "vitest";
+
+import { syncServerJson } from "./sync-server-json.mjs";
+
+const mcpName = "io.github.8ensmith/mcp-open-library";
+const packageName = "mcp-open-library";
+
+function makeServer() {
+  return {
+    $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    name: mcpName,
+    title: "Open Library",
+    description: "Search books and authors on the Internet Archive's Open Library",
+    version: "1.0.2",
+    websiteUrl: "https://github.com/8enSmith/mcp-open-library#readme",
+    repository: {
+      url: "https://github.com/8enSmith/mcp-open-library",
+      source: "github",
+    },
+    packages: [
+      {
+        registryType: "npm",
+        identifier: packageName,
+        version: "1.0.2",
+        transport: { type: "stdio" },
+      },
+    ],
+  };
+}
+
+describe("syncServerJson", () => {
+  it("updates the top-level version", () => {
+    const result = syncServerJson(makeServer(), {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+    expect(result.version).toBe("1.0.3");
+  });
+
+  it("updates the matching package entry version", () => {
+    const result = syncServerJson(makeServer(), {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+    expect(result.packages[0].version).toBe("1.0.3");
+  });
+
+  it("leaves package entries for other registries untouched", () => {
+    const server = makeServer();
+    server.packages.push({
+      registryType: "nuget",
+      identifier: "Someone.Else",
+      version: "9.9.9",
+      transport: { type: "stdio" },
+    });
+
+    const result = syncServerJson(server, {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+
+    expect(result.packages[1].version).toBe("9.9.9");
+  });
+
+  it("preserves every unrelated field", () => {
+    const server = makeServer();
+    const result = syncServerJson(server, {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+
+    expect(result.$schema).toBe(server.$schema);
+    expect(result.name).toBe(mcpName);
+    expect(result.title).toBe("Open Library");
+    expect(result.description).toBe(server.description);
+    expect(result.websiteUrl).toBe(server.websiteUrl);
+    expect(result.repository).toEqual(server.repository);
+    expect(result.packages[0].registryType).toBe("npm");
+    expect(result.packages[0].transport).toEqual({ type: "stdio" });
+  });
+
+  it("does not mutate the input", () => {
+    const server = makeServer();
+    syncServerJson(server, { version: "1.0.3", mcpName, packageName });
+    expect(server.version).toBe("1.0.2");
+    expect(server.packages[0].version).toBe("1.0.2");
+  });
+
+  it("throws when the server name does not match mcpName", () => {
+    expect(() =>
+      syncServerJson(makeServer(), {
+        version: "1.0.3",
+        mcpName: "io.github.8ensmith/something-else",
+        packageName,
+      }),
+    ).toThrow(/does not match/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run scripts/sync-server-json.test.mjs`
+Expected: FAIL — cannot resolve `./sync-server-json.mjs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `scripts/sync-server-json.mjs`:
+
+```js
+import { readFileSync, writeFileSync } from "node:fs";
+
+export function syncServerJson(server, { version, mcpName, packageName }) {
+  if (server.name !== mcpName) {
+    throw new Error(
+      `server.json name "${server.name}" does not match package.json mcpName "${mcpName}". ` +
+        "The server name is permanent and must be corrected by hand.",
+    );
+  }
+
+  return {
+    ...server,
+    version,
+    packages: server.packages.map((entry) =>
+      entry.identifier === packageName ? { ...entry, version } : entry,
+    ),
+  };
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const serverUrl = new URL("../server.json", import.meta.url);
+  const pkg = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const server = JSON.parse(readFileSync(serverUrl, "utf8"));
+
+  const updated = syncServerJson(server, {
+    version: pkg.version,
+    mcpName: pkg.mcpName,
+    packageName: pkg.name,
+  });
+
+  writeFileSync(serverUrl, `${JSON.stringify(updated, null, 2)}\n`);
+  console.log(`server.json synced to ${pkg.version}`);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run scripts/sync-server-json.test.mjs`
+Expected: PASS — 6 tests.
+
+- [ ] **Step 5: Add the `version` lifecycle hook to `package.json`**
+
+Add to `scripts`, immediately after the `"build"` entry:
+
+```json
+    "version": "node scripts/sync-server-json.mjs && git add server.json",
+```
+
+npm runs this after writing the new version to `package.json` and before creating the release commit, so the commit contains both files already in agreement.
+
+- [ ] **Step 6: Commit**
+
+Commit *before* exercising the hook. The next step's cleanup restores these files from `HEAD`, which would otherwise discard the hook you just added.
+
+```bash
+git add scripts/sync-server-json.mjs scripts/sync-server-json.test.mjs package.json
+git commit -m "feat: sync server.json from package.json on npm version"
+```
+
+- [ ] **Step 7: Verify the hook end-to-end without releasing anything**
+
+```bash
+npm version patch --no-git-tag-version
+node scripts/assert-release-consistency.mjs
+```
+
+Expected: `server.json` and `package.json` both now read `1.0.3`, and the checker reports consistent.
+
+Then undo it — the real bump happens at release time. The hook runs `git add server.json`, so the bump is **staged** as well as in the working tree; a plain `git checkout` would restore the staged copy and silently leave the bump in place. Reset both:
+
+```bash
+git restore --source=HEAD --staged --worktree package.json package-lock.json server.json
+node scripts/assert-release-consistency.mjs
+git status --short
+```
+
+Expected: both files back to `1.0.2`, checker still consistent, and `git status` clean.
+
+---
+
+### Task 4: Fix the `src/index.ts` version drift
+
+`src/index.ts:29` hardcodes `"1.0.0"` while the package is at `1.0.2`. Left alone, an automated release would publish `1.0.3` while the binary announces `1.0.0` to every client.
+
+**Files:**
+
+- Modify: `src/index.ts:1-10` (imports), `src/index.ts:29` (version)
+- Test: `src/index.test.ts` (add one test)
+
+**Interfaces:**
+
+- Consumes: `package.json` `version`.
+- Produces: no new exports. `OpenLibraryServer` keeps its existing signature.
+
+`new URL("../package.json", import.meta.url)` resolves to the repo root from `src/index.ts` under vitest, and to the package root from `build/index.js` at runtime and inside the published tarball. Both work without a build step.
+
+- [ ] **Step 1: Write the failing test**
+
+Add the `readFileSync` import to `src/index.test.ts`. It is a `node:` builtin, so it goes in the first import group, above the existing `@modelcontextprotocol` import, with a blank line after it (ESLint `import/order` requires this):
+
+```ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { readFileSync } from "node:fs";
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+```
+
+Then add this test inside the existing `describe("OpenLibraryServer", ...)` block, as the first `it` after `beforeEach`:
+
+```ts
+  it("reports the version from package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version: string };
+
+    const [implementation] = (Server as any).mock.calls[0];
+
+    expect(implementation.version).toBe(pkg.version);
+    expect(implementation.name).toBe("open-library-server");
+  });
+```
+
+`beforeEach` calls `vi.clearAllMocks()` and then constructs a fresh `OpenLibraryServer`, so `mock.calls[0]` is that construction's arguments.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/index.test.ts -t "reports the version from package.json"`
+Expected: FAIL — `expected '1.0.0' to be '1.0.2'`.
+
+This failure is the drift itself, reproduced.
+
+- [ ] **Step 3: Write the implementation**
+
+In `src/index.ts`, add the builtin import at the top of the import block (line 2, directly under the shebang) followed by a blank line:
+
+```ts
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+```
+
+Then, after the existing imports and before `class OpenLibraryServer`, add:
+
+```ts
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
+```
+
+And replace line 29:
+
+```ts
+        version: pkg.version,
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/index.test.ts -t "reports the version from package.json"`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the full suite and lint still pass**
+
+Run: `npm run build && npm run lint && npm run test:precommit`
+Expected: build succeeds, lint clean, all tests pass.
+
+The build step matters here: `vitest` also picks up the compiled tests under `build/`, so a stale `build/` will run the old assertions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.ts src/index.test.ts
+git commit -m "fix: report the real package version instead of a hardcoded 1.0.0"
+```
+
+---
+
+### Task 5: Release workflow
+
+**Files:**
+
+- Create: `.github/workflows/publish-mcp.yml`
+
+**Interfaces:**
+
+- Consumes: `scripts/assert-release-consistency.mjs` (Task 1), `server.json` (Task 2).
+- Produces: the published npm package and registry listing.
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # npm trusted publishing AND mcp-publisher OIDC
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test:precommit
+
+      - name: Build
+        run: npm run build
+
+      - name: Assert release metadata is consistent
+        run: node scripts/assert-release-consistency.mjs "${GITHUB_REF_NAME}"
+
+      - name: Publish package to npm
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "mcp-open-library@${VERSION}" version >/dev/null 2>&1; then
+            echo "mcp-open-library@${VERSION} is already on npm, skipping publish."
+          else
+            npm publish
+          fi
+
+      - name: Wait for npm to serve the new version
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          for attempt in $(seq 1 12); do
+            if npm view "mcp-open-library@${VERSION}" version >/dev/null 2>&1; then
+              echo "mcp-open-library@${VERSION} is visible on npm."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/12: not visible yet, retrying in 5s..."
+            sleep 5
+          done
+          echo "Timed out waiting for mcp-open-library@${VERSION} to appear on npm." >&2
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish
+```
+
+Three things here are deliberate and must not be "simplified":
+
+- `npm run test:precommit`, never `npm test` — see Global Constraints.
+- The `npm publish` guard. Without it, a registry-side failure leaves you unable to re-run: the retry dies on `E409 version already exists` and the release has to be finished by hand.
+- The propagation poll. The registry fetches `package.json` from npm to verify `mcpName`; losing that race surfaces as a misleading `Package validation failed`.
+
+- [ ] **Step 2: Check the workflow parses**
+
+Run: `npx --yes js-yaml .github/workflows/publish-mcp.yml > /dev/null && echo "YAML OK"`
+Expected: `YAML OK`. Any indentation or syntax error prints a parse error and exits non-zero.
+
+- [ ] **Step 3: Confirm the workflow cannot fire yet**
+
+Run: `git tag --list 'v*'`
+Expected: `v1.0.0`, `v1.0.1`, `v1.0.2` only. No new tag exists, so merging this workflow publishes nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/publish-mcp.yml
+git commit -m "ci: publish to npm and the MCP registry on version tags"
+```
+
+---
+
+### Task 6: Pull-request validation workflow
+
+Catches a malformed listing before a tag is cut. Independently droppable — if you would rather rely solely on the tag-time assertion in Task 5, skip this task entirely; nothing else depends on it.
+
+**Files:**
+
+- Create: `.github/workflows/validate-server-json.yml`
+
+**Interfaces:**
+
+- Consumes: `scripts/assert-release-consistency.mjs` (Task 1), `server.json` (Task 2).
+- Produces: nothing other tasks use.
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+name: Validate server.json
+
+on:
+  pull_request:
+    paths:
+      - server.json
+      - package.json
+      - scripts/**
+      - .github/workflows/validate-server-json.yml
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:precommit
+
+      - name: Assert release metadata is consistent
+        run: node scripts/assert-release-consistency.mjs
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+```
+
+No tag argument is passed, so the checker skips the tag comparison and asserts only the four file-to-file invariants. This job needs no `id-token` permission — it never authenticates.
+
+- [ ] **Step 2: Check the workflow parses and reproduce locally what the job will run**
+
+```bash
+npx --yes js-yaml .github/workflows/validate-server-json.yml > /dev/null && echo "YAML OK"
+npm run test:precommit
+node scripts/assert-release-consistency.mjs
+```
+
+Expected: `YAML OK`, tests pass, checker reports consistent.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/validate-server-json.yml
+git commit -m "ci: validate server.json on pull requests"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+
+- Modify: `README.md` (add a registry install section under `## Installation`)
+- Modify: `CHANGELOG.md` (add the missing `1.0.2` entry and an `Unreleased` section)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the registry section to `README.md`**
+
+Insert directly under the `## Installation` heading, above `### Installing via Smithery`:
+
+````markdown
+### MCP Registry
+
+This server is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) as
+`io.github.8ensmith/mcp-open-library`. Clients that support the registry can install it by that name.
+
+To inspect the published listing:
+
+```bash
+curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+```
+````
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+The file currently jumps from `1.0.1` straight back to `1.0.0` — the released `1.0.2` was never recorded. Add both sections directly above the existing `## [1.0.1]` heading:
+
+```markdown
+## [Unreleased]
+### Added
+- Published to the official MCP Registry as `io.github.8ensmith/mcp-open-library`
+- Automated release pipeline: version tags publish to npm and the MCP Registry over OIDC
+
+### Fixed
+- Server now reports its real package version instead of a hardcoded `1.0.0`
+
+## [1.0.2] - 2026-02-04
+### Changed
+- Updated dependencies
+```
+
+At release time the `Unreleased` heading becomes `## [1.0.3] - <date>`.
+
+- [ ] **Step 3: Verify the docs render**
+
+Run: `npx --yes markdownlint-cli2 README.md CHANGELOG.md 2>&1 | tail -20 || true`
+Expected: no errors introduced by the new sections. Pre-existing warnings elsewhere in the files are not this task's concern.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: document the MCP registry listing and release process"
+```
+
+---
+
+## After the plan: releasing
+
+These steps are **not** part of the implementation and must not be run by an implementing agent. They are the human release procedure, recorded here so it is not lost.
+
+1. **Open and merge the PR.** Nothing publishes — `publish-mcp.yml` is tag-triggered only.
+
+2. **Configure the npm trusted publisher.** npmjs.com → `mcp-open-library` → Settings → Trusted publisher:
+   - Owner: `8enSmith`
+   - Repository: `mcp-open-library`
+   - Workflow: `publish-mcp.yml`
+
+   Without this the publish step fails.
+
+3. **Pre-flight the namespace.** The server name is permanent, so confirm the lowercase form is what the registry actually grants:
+
+   ```bash
+   mcp-publisher login github
+   node -e "const t=require(require('os').homedir()+'/.config/mcp-publisher/token.json').token; console.log(JSON.parse(Buffer.from(t.split('.')[1],'base64url')))"
+   ```
+
+   Expected: a permissions claim covering `io.github.8ensmith/*`. If it shows a different case, correct `server.json` `name` and `package.json` `mcpName` together before releasing.
+
+4. **Promote the changelog.** Rename `## [Unreleased]` to `## [1.0.3] - <today>`.
+
+5. **Cut the release:**
+
+   ```bash
+   npm version patch
+   git push --follow-tags
+   ```
+
+6. **Verify:**
+
+   ```bash
+   npm view mcp-open-library@1.0.3 mcpName
+   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+   ```
+
+   The first must print `io.github.8ensmith/mcp-open-library`; the second must return the listing.
+
+If the registry step fails after npm succeeded, fix the cause and re-run the workflow from the Actions tab. The npm step self-skips, so the re-run picks up where it failed.

--- a/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
+++ b/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
@@ -635,8 +635,11 @@ git commit -m "fix: report the real package version instead of a hardcoded 1.0.0
 
 > **⚠️ Superseded — do not copy the YAML below.** `.github/workflows/publish-mcp.yml` as shipped is
 > authoritative. Post-review changes: `mcp-publisher` install and `validate` moved *before*
-> `npm publish` so a registry-side failure cannot leave npm published without a listing; the binary
-> is pinned to `v1.8.1` and checksum-verified instead of piping `releases/latest` into `tar`; and the
+> `npm publish`, so a malformed listing is caught before npm publishes irreversibly. That narrows the
+> partial-release window but does not close it — `login github-oidc` and `publish` still run after
+> npm, so a registry-side failure there can still leave npm published without a listing; the guarded
+> `npm publish` step is what makes re-running the workflow safe in that case. The binary is also
+> pinned to `v1.8.1` and checksum-verified instead of piping `releases/latest` into `tar`, and the
 > download block sets `set -euo pipefail` with `curl --fail`.
 
 **Files:**

--- a/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
+++ b/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
@@ -633,6 +633,12 @@ git commit -m "fix: report the real package version instead of a hardcoded 1.0.0
 
 ### Task 5: Release workflow
 
+> **⚠️ Superseded — do not copy the YAML below.** `.github/workflows/publish-mcp.yml` as shipped is
+> authoritative. Post-review changes: `mcp-publisher` install and `validate` moved *before*
+> `npm publish` so a registry-side failure cannot leave npm published without a listing; the binary
+> is pinned to `v1.8.1` and checksum-verified instead of piping `releases/latest` into `tar`; and the
+> download block sets `set -euo pipefail` with `curl --fail`.
+
 **Files:**
 
 - Create: `.github/workflows/publish-mcp.yml`
@@ -750,6 +756,12 @@ git commit -m "ci: publish to npm and the MCP registry on version tags"
 ---
 
 ### Task 6: Pull-request validation workflow
+
+> **⚠️ Superseded — do not copy the YAML below.** `.github/workflows/validate-server-json.yml` as
+> shipped is authoritative. Post-review changes: the `mcp-publisher` binary is pinned to `v1.8.1` and
+> checksum-verified rather than pulled from `releases/latest`; the download block sets
+> `set -euo pipefail` with `curl --fail`; and `CHANGELOG.md` was added to the `paths` filter once the
+> consistency checker began reading it.
 
 Catches a malformed listing before a tag is cut. Independently droppable — if you would rather rely solely on the tag-time assertion in Task 5, skip this task entirely; nothing else depends on it.
 
@@ -911,7 +923,7 @@ These steps are **not** part of the implementation and must not be run by an imp
    node -e "const t=require(require('os').homedir()+'/.config/mcp-publisher/token.json').token; console.log(JSON.parse(Buffer.from(t.split('.')[1],'base64url')))"
    ```
 
-   Expected: a permissions claim covering `io.github.8enSmith/*` — note the capital `S`. This was run on 2026-08-09 and confirmed exactly that, overturning the original lowercase assumption. If it ever shows a different case, correct `server.json` `name` and `package.json` `mcpName` together before releasing.
+   Expected: a permissions claim covering `io.github.8enSmith/*` — note the capital `S`. This was run against the live registry during implementation and returned exactly that, overturning the original lowercase assumption; the resulting correction is commit `368b4b6`. If it ever shows a different case, correct `server.json` `name` and `package.json` `mcpName` together before releasing.
 
 4. **Check `CHANGELOG.md` has a `## [Unreleased]` section** describing this release. Promoting it to
    `## [1.0.3] - <today>` is now automatic — `scripts/promote-changelog.mjs` runs from the `version`

--- a/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
+++ b/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
@@ -21,7 +21,7 @@
 - Workflows that publish need **`id-token: write`** — one permission covers both npm OIDC and `mcp-publisher login github-oidc`.
 - **`server.json` is committed at version `1.0.2`, matching today's `package.json`.** The spec shows `1.0.3` because that is what ships; the bump to `1.0.3` happens later via `npm version patch`. Committing `1.0.3` now would make the Task 1 checker fail on every PR.
 - New scripts are plain `.mjs`, not TypeScript. The `version` hook must run before any build step exists, so these files cannot depend on `tsc` output.
-- Scripts follow the existing direct-invocation idiom from `src/index.ts:75`: `if (process.argv[1] === new URL(import.meta.url).pathname)`.
+- Scripts use `if (process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url))` to detect direct invocation, not the `src/index.ts:75` idiom (`process.argv[1] === new URL(import.meta.url).pathname`) — that comparison fails open (silently exits 0) when the checkout path contains a space or is reached via a symlink, which is unacceptable for a release gate. `src/index.ts` keeps its existing idiom; it is out of scope here.
 - ESLint enforces `import/order` with `newlines-between: always`. `node:` builtins go in the first group, followed by a blank line.
 - Conventional commits (the repo uses commitizen).
 

--- a/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
+++ b/docs/superpowers/plans/2026-08-08-publish-to-mcp-registry.md
@@ -913,7 +913,10 @@ These steps are **not** part of the implementation and must not be run by an imp
 
    Expected: a permissions claim covering `io.github.8enSmith/*` — note the capital `S`. This was run on 2026-08-09 and confirmed exactly that, overturning the original lowercase assumption. If it ever shows a different case, correct `server.json` `name` and `package.json` `mcpName` together before releasing.
 
-4. **Promote the changelog.** Rename `## [Unreleased]` to `## [1.0.3] - <today>`.
+4. **Check `CHANGELOG.md` has a `## [Unreleased]` section** describing this release. Promoting it to
+   `## [1.0.3] - <today>` is now automatic — `scripts/promote-changelog.mjs` runs from the `version`
+   lifecycle hook. `npm version` fails if the heading is missing rather than releasing something
+   undocumented. The canonical runbook now lives in the README's Development → Releasing section.
 
 5. **Cut the release:**
 

--- a/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
@@ -246,8 +246,10 @@ Both must happen before the first tag is pushed.
 1. Land the repo changes via PR. Nothing publishes — the workflow is tag-only.
 2. Configure the npm trusted publisher.
 3. Run the namespace pre-flight.
-4. `npm version patch` → `git push --follow-tags`.
-5. Verify:
+4. Confirm `CHANGELOG.md` has a `## [Unreleased]` section describing the release. The `version` hook
+   promotes it to `## [<version>] - <date>` automatically and fails the bump if it is missing.
+5. `npm version patch` → `git push --follow-tags`.
+6. Verify:
 
    ```bash
    npm view mcp-open-library@1.0.3 mcpName

--- a/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
@@ -1,0 +1,260 @@
+# Publishing mcp-open-library to the official MCP Registry
+
+**Date:** 2026-08-08
+**Status:** Approved
+
+## Goal
+
+List `mcp-open-library` in the official MCP Registry as `io.github.8ensmith/mcp-open-library`, and
+replace today's manual npm release with a secretless, tag-triggered pipeline that publishes to npm
+and the registry together.
+
+## Background
+
+The registry stores metadata only; the artifact stays on npm. It proves you own the npm package by
+fetching your published `package.json` and checking that `mcpName` matches the server name in
+`server.json`.
+
+`mcp-open-library@1.0.2` is already on npm without `mcpName`. npm metadata cannot be amended in
+place, so a new npm release is unavoidable — the first registry listing ships as `1.0.3`.
+
+The repo currently has no release automation. `.github/workflows/` contains only `pr-greeter.yml`;
+npm publishing is manual and tests run only through the husky pre-commit hook.
+
+## The core problem
+
+Once `server.json` exists, the release version is duplicated across five locations, and the server
+identity across two more — all of which must agree:
+
+| Location                            | Kind     | Value                                 |
+| ----------------------------------- | -------- | ------------------------------------- |
+| `package.json` `version`            | version  | `1.0.3`                               |
+| `server.json` `version`             | version  | `1.0.3`                               |
+| `server.json` `packages[0].version` | version  | `1.0.3`                               |
+| git tag                             | version  | `v1.0.3`                              |
+| `src/index.ts` `version`            | version  | `"1.0.0"` — already drifted           |
+| `package.json` `mcpName`            | identity | `io.github.8ensmith/mcp-open-library` |
+| `server.json` `name`                | identity | `io.github.8ensmith/mcp-open-library` |
+
+Drift either fails the publish or, worse, ships a listing that misrepresents the package. The design
+is chosen to make drift structurally impossible rather than merely detected.
+
+**Single source of truth: `package.json` `version`.** Everything else is derived from or asserted
+against it.
+
+## Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Scope | Full release automation | Keeps npm and registry versions in lockstep forever, not just once |
+| Server name | `io.github.8ensmith/mcp-open-library` | Exactly matches repo and npm package name |
+| npm auth | Trusted publishing (OIDC) | No stored credential; adds build provenance |
+| Registry auth | `mcp-publisher login github-oidc` | No stored credential |
+| Version sync | `npm version` lifecycle hook | Only approach where the repo cannot go inconsistent |
+
+Both OIDC flows are covered by a single `id-token: write` permission, so the pipeline holds no
+secrets at all.
+
+## Components
+
+### `server.json` (new, repo root)
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.8ensmith/mcp-open-library",
+  "title": "Open Library",
+  "description": "Search books and authors on the Internet Archive's Open Library",
+  "version": "1.0.3",
+  "websiteUrl": "https://github.com/8enSmith/mcp-open-library#readme",
+  "repository": {
+    "url": "https://github.com/8enSmith/mcp-open-library",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "mcp-open-library",
+      "version": "1.0.3",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}
+```
+
+The schema caps `description` at 100 characters; the string above is 62. No `environmentVariables`
+or `packageArguments` — the server takes no configuration.
+
+### `package.json` (changed)
+
+- Add `"mcpName": "io.github.8ensmith/mcp-open-library"`.
+- Add a `version` lifecycle script:
+
+  ```json
+  "version": "node scripts/sync-server-json.mjs && git add server.json"
+  ```
+
+  npm runs this after bumping the version and before creating the commit, so `npm version patch`
+  yields one commit and tag with every file already consistent.
+
+### `scripts/sync-server-json.mjs` (new)
+
+A pure function plus a thin CLI wrapper, so the logic is unit-testable without touching disk.
+
+- `syncServerJson(serverJson, { version, mcpName })` → returns the updated object. Throws if
+  `serverJson.name !== mcpName`.
+- The wrapper reads both files, calls the function, and writes `server.json` back preserving
+  two-space indentation and the trailing newline.
+
+Sole responsibility: make `server.json` agree with `package.json`. It does not publish, tag, or bump.
+
+### `scripts/assert-release-consistency.mjs` (new)
+
+Same shape — pure function plus CLI wrapper. Given the tag name and both JSON files, asserts:
+
+```text
+tag minus "v"                      === package.json version
+server.json version                === package.json version
+server.json packages[0].version    === package.json version
+server.json name                   === package.json mcpName
+server.json packages[0].identifier === package.json name
+```
+
+Each mismatch reports which pair disagreed. The tag check is skipped when no tag is supplied, so the
+same script serves PR validation.
+
+### `src/index.ts` (changed)
+
+Replace the hardcoded `version: "1.0.0"` at line 29 with a read from `package.json`:
+
+```ts
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+```
+
+`tsconfig.json` sets `rootDir: ./src` and `outDir: ./build`, so from `build/index.js` this resolves
+to the package root in both the repo and the published tarball.
+
+This drift predates the work, but an automated release that publishes `1.0.3` while the binary
+announces `1.0.0` to every client is precisely the failure this design exists to prevent.
+
+### `.github/workflows/publish-mcp.yml` (new)
+
+Triggered by `push` on tags matching `v*`, consistent with the existing `v1.0.0`–`v1.0.2` tags.
+
+```yaml
+permissions:
+  id-token: write   # npm trusted publishing AND mcp-publisher OIDC
+  contents: read
+```
+
+Steps:
+
+1. `actions/checkout`
+2. `actions/setup-node` with `node-version-file: .nvmrc` (pins v22.21.1)
+3. `npm install -g npm@latest` — Node 22 ships npm 10.x; trusted publishing requires ≥ 11.5.1
+4. `npm ci`
+5. `npm run lint`
+6. `npm run test:precommit`
+7. `npm run build`
+8. `node scripts/assert-release-consistency.mjs "$GITHUB_REF_NAME"`
+9. Guarded `npm publish`
+10. Poll npm until the new version is served
+11. Install `mcp-publisher`, then `validate` → `login github-oidc` → `publish`
+
+### `.github/workflows/validate-server-json.yml` (new)
+
+On pull requests touching `server.json` or `package.json`: run the consistency assertion without a
+tag, plus `mcp-publisher validate`. Catches a malformed listing before a tag is cut, while it is
+still cheap to fix.
+
+### Documentation (changed)
+
+- `README.md` — installation via the MCP Registry.
+- `CHANGELOG.md` — add the missing `1.0.2` entry and a `1.0.3` entry.
+
+## Three details that matter more than they look
+
+**Use `test:precommit`, not `test`.** The `test` script is bare `vitest`, which is watch mode and
+would hang the runner until the job times out. The MCP registry docs show `npm run test --if-present`;
+copied verbatim it breaks this repo. Only `test:precommit` (`vitest run`) is safe in CI.
+
+**Guard `npm publish`.** The realistic failure is npm succeeding and the registry step failing after
+it. Ungated, re-running the tag build dies on `E409 version already exists`, leaving the release
+half-done and needing a hand-run `mcp-publisher`.
+
+```bash
+VERSION=$(node -p "require('./package.json').version")
+if npm view "mcp-open-library@$VERSION" version >/dev/null 2>&1; then
+  echo "Already published to npm, skipping"
+else
+  npm publish
+fi
+```
+
+Re-running the whole workflow then converges rather than failing.
+
+**Poll for npm propagation.** The registry fetches `package.json` from npm to verify `mcpName`.
+Publish-to-readable is not instant, and losing that race surfaces as a misleading
+`Package validation failed`. Poll `npm view mcp-open-library@$VERSION` with a ceiling of roughly 60
+seconds.
+
+## Error handling
+
+| Failure | Behaviour | Recovery |
+| --- | --- | --- |
+| Tag disagrees with `package.json` | Step 8 fails before anything is published | Fix, delete tag, re-tag |
+| `server.json` invalid | `mcp-publisher validate` fails; caught earlier on PRs | Fix and re-tag |
+| npm publish fails | Nothing reaches the registry | Fix, re-run workflow |
+| Registry publish fails after npm succeeded | npm step self-skips on re-run | Re-run workflow |
+| npm not yet propagated | Poll absorbs it | Automatic |
+
+## Testing
+
+Vitest unit tests against the two pure functions:
+
+- `syncServerJson` — bumps both version fields, preserves unrelated keys, throws on a
+  name/`mcpName` mismatch.
+- The consistency checker — passes when aligned, fails on each of the five mismatches individually.
+
+The workflow itself gets no test; it is proven by the first real tag push.
+
+## Manual steps (cannot be automated)
+
+Both must happen before the first tag is pushed.
+
+1. **npm trusted publisher.** npmjs.com → `mcp-open-library` → Settings → Trusted publisher. Owner
+   `8enSmith`, repo `mcp-open-library`, workflow `publish-mcp.yml`. Without this, the publish step
+   fails.
+2. **Namespace pre-flight.** The GitHub login is mixed-case (`8enSmith`) but registry namespaces are
+   lowercase (`io.github.8ensmith`). The server name is permanent and unrenameable, so confirm it
+   rather than assume: run `mcp-publisher login github` locally and decode
+   `~/.config/mcp-publisher/token.json` to read the granted namespace claim.
+
+## Rollout
+
+1. Land the repo changes via PR. Nothing publishes — the workflow is tag-only.
+2. Configure the npm trusted publisher.
+3. Run the namespace pre-flight.
+4. `npm version patch` → `git push --follow-tags`.
+5. Verify:
+
+   ```bash
+   npm view mcp-open-library@1.0.3 mcpName
+   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+   ```
+
+## Out of scope
+
+- **General test CI.** The repo has no workflow running tests on PRs; tests run only via the husky
+  pre-commit hook. Worth fixing, but it is a separate concern from publishing.
+- **Compiled tests in the published tarball.** `build/` contains `index.test.js` and `files:
+  ["build"]` ships it to npm. A packaging wart, unrelated to this work.
+- **Smithery, Glama and other existing listings.** Unaffected.
+
+## Notes
+
+An unrelated `io.github.pipeworx-io/open-library` (a remote server behind a gateway) already exists
+in the registry. Different namespace, so there is no conflict — noted only so it is not a surprise
+when searching.

--- a/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
@@ -163,7 +163,9 @@ Steps:
 6. `npm run test:precommit`
 7. `npm run build`
 8. `node scripts/assert-release-consistency.mjs "$GITHUB_REF_NAME"`
-9. Install `mcp-publisher` → `validate` (before npm publish, so a registry-side failure never leaves npm published without a listing)
+9. Install `mcp-publisher` → `validate` (before npm publish, so a malformed listing is caught before
+   npm publishes irreversibly — `login` and `publish` still run after npm, so a failure there can
+   still strand npm ahead of the registry; the guarded npm step makes the re-run safe)
 10. Guarded `npm publish`
 11. Poll npm until the new version is served
 12. `login github-oidc` → `publish`

--- a/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
@@ -5,7 +5,7 @@
 
 ## Goal
 
-List `mcp-open-library` in the official MCP Registry as `io.github.8ensmith/mcp-open-library`, and
+List `mcp-open-library` in the official MCP Registry as `io.github.8enSmith/mcp-open-library`, and
 replace today's manual npm release with a secretless, tag-triggered pipeline that publishes to npm
 and the registry together.
 
@@ -33,8 +33,8 @@ identity across two more — all of which must agree:
 | `server.json` `packages[0].version` | version  | `1.0.3`                               |
 | git tag                             | version  | `v1.0.3`                              |
 | `src/index.ts` `version`            | version  | `"1.0.0"` — already drifted           |
-| `package.json` `mcpName`            | identity | `io.github.8ensmith/mcp-open-library` |
-| `server.json` `name`                | identity | `io.github.8ensmith/mcp-open-library` |
+| `package.json` `mcpName`            | identity | `io.github.8enSmith/mcp-open-library` |
+| `server.json` `name`                | identity | `io.github.8enSmith/mcp-open-library` |
 
 Drift either fails the publish or, worse, ships a listing that misrepresents the package. The design
 is chosen to make drift structurally impossible rather than merely detected.
@@ -47,7 +47,7 @@ against it.
 | Decision | Choice | Why |
 | --- | --- | --- |
 | Scope | Full release automation | Keeps npm and registry versions in lockstep forever, not just once |
-| Server name | `io.github.8ensmith/mcp-open-library` | Exactly matches repo and npm package name |
+| Server name | `io.github.8enSmith/mcp-open-library` | Exactly matches repo and npm package name |
 | npm auth | Trusted publishing (OIDC) | No stored credential; adds build provenance |
 | Registry auth | `mcp-publisher login github-oidc` | No stored credential |
 | Version sync | `npm version` lifecycle hook | Only approach where the repo cannot go inconsistent |
@@ -62,7 +62,7 @@ secrets at all.
 ```json
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.8ensmith/mcp-open-library",
+  "name": "io.github.8enSmith/mcp-open-library",
   "title": "Open Library",
   "description": "Search books and authors on the Internet Archive's Open Library",
   "version": "1.0.3",
@@ -87,7 +87,7 @@ or `packageArguments` — the server takes no configuration.
 
 ### `package.json` (changed)
 
-- Add `"mcpName": "io.github.8ensmith/mcp-open-library"`.
+- Add `"mcpName": "io.github.8enSmith/mcp-open-library"`.
 - Add a `version` lifecycle script:
 
   ```json
@@ -228,9 +228,17 @@ Both must happen before the first tag is pushed.
 1. **npm trusted publisher.** npmjs.com → `mcp-open-library` → Settings → Trusted publisher. Owner
    `8enSmith`, repo `mcp-open-library`, workflow `publish-mcp.yml`. Without this, the publish step
    fails.
-2. **Namespace pre-flight.** The GitHub login is mixed-case (`8enSmith`) but registry namespaces are
-   lowercase (`io.github.8ensmith`). The server name is permanent and unrenameable, so confirm it
-   rather than assume: run `mcp-publisher login github` locally and decode
+2. **Namespace pre-flight.** *Done — and it overturned an assumption.* This design originally
+   assumed registry namespaces were lowercased to `io.github.8ensmith`. They are not. The registry
+   builds the grant as `io.github.<owner>/*` from GitHub's login verbatim — `io.github.8enSmith/*`,
+   capital `S` — on both the access-token and OIDC paths (`internal/api/handlers/v0/auth/github_oidc.go:293`),
+   and matches it against the raw `server.json` name with a case-sensitive `strings.HasPrefix`
+   (`internal/auth/jwt.go:165-173`). The lowercased name would have been rejected — and because
+   `validate` does not check namespace permissions, the rejection would have landed at
+   `mcp-publisher publish`, after npm had already published immutably. The name is now
+   `io.github.8enSmith/mcp-open-library` everywhere.
+
+   To re-verify at any time: run `mcp-publisher login github` and decode
    `~/.config/mcp-publisher/token.json` to read the granted namespace claim.
 
 ## Rollout
@@ -243,7 +251,7 @@ Both must happen before the first tag is pushed.
 
    ```bash
    npm view mcp-open-library@1.0.3 mcpName
-   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8ensmith/mcp-open-library"
+   curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.8enSmith/mcp-open-library"
    ```
 
 ## Out of scope

--- a/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
@@ -91,11 +91,15 @@ or `packageArguments` — the server takes no configuration.
 - Add a `version` lifecycle script:
 
   ```json
-  "version": "node scripts/sync-server-json.mjs && git add server.json"
+  "version": "node scripts/sync-server-json.mjs && node scripts/promote-changelog.mjs && git add server.json CHANGELOG.md"
   ```
 
   npm runs this after bumping the version and before creating the commit, so `npm version patch`
   yields one commit and tag with every file already consistent.
+
+  The changelog promotion was added after the original design: leaving it manual meant npm and the
+  registry could say `1.0.3` while `CHANGELOG.md` still read `## [Unreleased]`. See
+  `scripts/promote-changelog.mjs`.
 
 ### `scripts/sync-server-json.mjs` (new)
 

--- a/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
+++ b/docs/superpowers/specs/2026-08-08-mcp-registry-publishing-design.md
@@ -159,9 +159,10 @@ Steps:
 6. `npm run test:precommit`
 7. `npm run build`
 8. `node scripts/assert-release-consistency.mjs "$GITHUB_REF_NAME"`
-9. Guarded `npm publish`
-10. Poll npm until the new version is served
-11. Install `mcp-publisher`, then `validate` → `login github-oidc` → `publish`
+9. Install `mcp-publisher` → `validate` (before npm publish, so a registry-side failure never leaves npm published without a listing)
+10. Guarded `npm publish`
+11. Poll npm until the new version is served
+12. `login github-oidc` → `publish`
 
 ### `.github/workflows/validate-server-json.yml` (new)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,11 @@ export default defineConfig([{
 
     languageOptions: {
         parser: tsParser,
+        globals: {
+            console: "readonly",
+            process: "readonly",
+            URL: "readonly",
+        },
     },
 
     rules: {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
-    "version": "node scripts/sync-server-json.mjs && git add server.json",
+    "version": "node scripts/sync-server-json.mjs && node scripts/promote-changelog.mjs && git add server.json CHANGELOG.md",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "mcp-open-library",
   "version": "1.0.2",
   "description": "MCP server for the Open Library",
+  "mcpName": "io.github.8ensmith/mcp-open-library",
   "private": false,
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
     "test": "vitest",
     "format": "prettier --write src/**/*.ts",
-    "lint": "eslint src --ext .ts",
-    "lint:fix": "eslint src --ext .ts --fix",
+    "lint": "eslint src scripts",
+    "lint:fix": "eslint src scripts --fix",
     "test:precommit": "vitest run"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mcp-open-library",
   "version": "1.0.2",
   "description": "MCP server for the Open Library",
-  "mcpName": "io.github.8ensmith/mcp-open-library",
+  "mcpName": "io.github.8enSmith/mcp-open-library",
   "private": false,
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "version": "node scripts/sync-server-json.mjs && git add server.json",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",

--- a/scripts/assert-release-consistency.mjs
+++ b/scripts/assert-release-consistency.mjs
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+
+export function checkReleaseConsistency({ pkg, server, tag }) {
+  const problems = [];
+  const version = pkg.version;
+
+  if (tag !== undefined) {
+    const tagVersion = tag.startsWith("v") ? tag.slice(1) : tag;
+    if (tagVersion !== version) {
+      problems.push(
+        `git tag "${tag}" does not match package.json version "${version}"`,
+      );
+    }
+  }
+
+  if (server.version !== version) {
+    problems.push(
+      `server.json version "${server.version}" does not match package.json version "${version}"`,
+    );
+  }
+
+  const entry = server.packages?.[0];
+
+  if (!entry) {
+    problems.push("server.json has no packages[0] entry");
+  } else {
+    if (entry.version !== version) {
+      problems.push(
+        `server.json packages[0].version "${entry.version}" does not match package.json version "${version}"`,
+      );
+    }
+    if (entry.identifier !== pkg.name) {
+      problems.push(
+        `server.json packages[0].identifier "${entry.identifier}" does not match package.json name "${pkg.name}"`,
+      );
+    }
+  }
+
+  if (server.name !== pkg.mcpName) {
+    problems.push(
+      `server.json name "${server.name}" does not match package.json mcpName "${pkg.mcpName}"`,
+    );
+  }
+
+  return problems;
+}
+
+function readJson(relativePath) {
+  return JSON.parse(
+    readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+  );
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const problems = checkReleaseConsistency({
+    pkg: readJson("../package.json"),
+    server: readJson("../server.json"),
+    tag: process.argv[2],
+  });
+
+  if (problems.length > 0) {
+    console.error("Release metadata is inconsistent:");
+    for (const problem of problems) {
+      console.error(`  - ${problem}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Release metadata is consistent.");
+}

--- a/scripts/assert-release-consistency.mjs
+++ b/scripts/assert-release-consistency.mjs
@@ -1,7 +1,7 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-export function checkReleaseConsistency({ pkg, server, tag }) {
+export function checkReleaseConsistency({ pkg, server, tag, changelog }) {
   const problems = [];
   const version = pkg.version;
 
@@ -43,6 +43,12 @@ export function checkReleaseConsistency({ pkg, server, tag }) {
     );
   }
 
+  if (changelog !== undefined && !changelog.includes(`## [${version}]`)) {
+    problems.push(
+      `CHANGELOG.md has no "## [${version}]" entry for package.json version "${version}"`,
+    );
+  }
+
   return problems;
 }
 
@@ -60,6 +66,10 @@ if (
     pkg: readJson("../package.json"),
     server: readJson("../server.json"),
     tag: process.argv[2],
+    changelog: readFileSync(
+      new URL("../CHANGELOG.md", import.meta.url),
+      "utf8",
+    ),
   });
 
   if (problems.length > 0) {

--- a/scripts/assert-release-consistency.mjs
+++ b/scripts/assert-release-consistency.mjs
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export function checkReleaseConsistency({ pkg, server, tag }) {
   const problems = [];
@@ -51,7 +52,10 @@ function readJson(relativePath) {
   );
 }
 
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   const problems = checkReleaseConsistency({
     pkg: readJson("../package.json"),
     server: readJson("../server.json"),

--- a/scripts/assert-release-consistency.test.mjs
+++ b/scripts/assert-release-consistency.test.mjs
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+
+import { checkReleaseConsistency } from "./assert-release-consistency.mjs";
+
+const pkg = {
+  name: "mcp-open-library",
+  version: "1.0.3",
+  mcpName: "io.github.8ensmith/mcp-open-library",
+};
+
+const server = {
+  name: "io.github.8ensmith/mcp-open-library",
+  version: "1.0.3",
+  packages: [{ identifier: "mcp-open-library", version: "1.0.3" }],
+};
+
+describe("checkReleaseConsistency", () => {
+  it("returns no problems when everything agrees", () => {
+    expect(checkReleaseConsistency({ pkg, server, tag: "v1.0.3" })).toEqual([]);
+  });
+
+  it("skips the tag check when no tag is supplied", () => {
+    expect(checkReleaseConsistency({ pkg, server })).toEqual([]);
+  });
+
+  it("accepts a tag without the v prefix", () => {
+    expect(checkReleaseConsistency({ pkg, server, tag: "1.0.3" })).toEqual([]);
+  });
+
+  it("reports a tag that does not match package.json", () => {
+    const problems = checkReleaseConsistency({ pkg, server, tag: "v9.9.9" });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("git tag");
+  });
+
+  it("reports a server.json version mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: { ...server, version: "1.0.2" },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("server.json version");
+  });
+
+  it("reports a packages[0].version mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: {
+        ...server,
+        packages: [{ identifier: "mcp-open-library", version: "1.0.2" }],
+      },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("packages[0].version");
+  });
+
+  it("reports a packages[0].identifier mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: {
+        ...server,
+        packages: [{ identifier: "wrong-package", version: "1.0.3" }],
+      },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("packages[0].identifier");
+  });
+
+  it("reports a name/mcpName mismatch", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: { ...server, name: "io.github.8ensmith/wrong-name" },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("mcpName");
+  });
+
+  it("reports a missing packages entry", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: { ...server, packages: [] },
+      tag: "v1.0.3",
+    });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("packages[0]");
+  });
+
+  it("reports every problem at once rather than stopping at the first", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server: {
+        name: "io.github.8ensmith/wrong-name",
+        version: "1.0.1",
+        packages: [{ identifier: "wrong-package", version: "1.0.2" }],
+      },
+      tag: "v9.9.9",
+    });
+    expect(problems).toHaveLength(5);
+  });
+});

--- a/scripts/assert-release-consistency.test.mjs
+++ b/scripts/assert-release-consistency.test.mjs
@@ -5,11 +5,11 @@ import { checkReleaseConsistency } from "./assert-release-consistency.mjs";
 const pkg = {
   name: "mcp-open-library",
   version: "1.0.3",
-  mcpName: "io.github.8ensmith/mcp-open-library",
+  mcpName: "io.github.8enSmith/mcp-open-library",
 };
 
 const server = {
-  name: "io.github.8ensmith/mcp-open-library",
+  name: "io.github.8enSmith/mcp-open-library",
   version: "1.0.3",
   packages: [{ identifier: "mcp-open-library", version: "1.0.3" }],
 };
@@ -72,7 +72,7 @@ describe("checkReleaseConsistency", () => {
   it("reports a name/mcpName mismatch", () => {
     const problems = checkReleaseConsistency({
       pkg,
-      server: { ...server, name: "io.github.8ensmith/wrong-name" },
+      server: { ...server, name: "io.github.8enSmith/wrong-name" },
       tag: "v1.0.3",
     });
     expect(problems).toHaveLength(1);
@@ -93,7 +93,7 @@ describe("checkReleaseConsistency", () => {
     const problems = checkReleaseConsistency({
       pkg,
       server: {
-        name: "io.github.8ensmith/wrong-name",
+        name: "io.github.8enSmith/wrong-name",
         version: "1.0.1",
         packages: [{ identifier: "wrong-package", version: "1.0.2" }],
       },

--- a/scripts/assert-release-consistency.test.mjs
+++ b/scripts/assert-release-consistency.test.mjs
@@ -14,9 +14,50 @@ const server = {
   packages: [{ identifier: "mcp-open-library", version: "1.0.3" }],
 };
 
+const changelog = `# Changelog
+
+## [1.0.3] - 2026-08-09
+### Added
+- The thing
+
+## [1.0.2] - 2026-02-04
+### Changed
+- Updated dependencies
+`;
+
 describe("checkReleaseConsistency", () => {
   it("returns no problems when everything agrees", () => {
     expect(checkReleaseConsistency({ pkg, server, tag: "v1.0.3" })).toEqual([]);
+  });
+
+  it("returns no problems when the changelog has an entry for the version", () => {
+    expect(
+      checkReleaseConsistency({ pkg, server, tag: "v1.0.3", changelog }),
+    ).toEqual([]);
+  });
+
+  it("skips the changelog check when no changelog is supplied", () => {
+    expect(checkReleaseConsistency({ pkg, server, tag: "v1.0.3" })).toEqual([]);
+  });
+
+  it("reports a changelog with no entry for the version being released", () => {
+    const problems = checkReleaseConsistency({
+      pkg,
+      server,
+      tag: "v1.0.3",
+      changelog: `# Changelog
+
+## [Unreleased]
+### Added
+- Forgot to promote this before releasing
+
+## [1.0.2] - 2026-02-04
+`,
+    });
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("CHANGELOG.md");
+    expect(problems[0]).toContain("1.0.3");
   });
 
   it("skips the tag check when no tag is supplied", () => {

--- a/scripts/promote-changelog.mjs
+++ b/scripts/promote-changelog.mjs
@@ -1,0 +1,43 @@
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const UNRELEASED_HEADING = /^## \[Unreleased\].*$/m;
+
+export function promoteChangelog(changelog, { version, date }) {
+  if (changelog.includes(`## [${version}]`)) {
+    throw new Error(
+      `CHANGELOG.md already has a "## [${version}]" entry. ` +
+        "Refusing to promote in case this version was already released.",
+    );
+  }
+
+  if (!UNRELEASED_HEADING.test(changelog)) {
+    throw new Error(
+      'CHANGELOG.md has no "## [Unreleased]" section to promote. ' +
+        "Add one describing this release, then run npm version again. " +
+        "To undo the partial bump: git restore --source=HEAD --staged --worktree " +
+        "package.json package-lock.json server.json",
+    );
+  }
+
+  return changelog.replace(UNRELEASED_HEADING, `## [${version}] - ${date}`);
+}
+
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  const changelogUrl = new URL("../CHANGELOG.md", import.meta.url);
+  const pkg = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const date = new Date().toISOString().slice(0, 10);
+
+  const promoted = promoteChangelog(readFileSync(changelogUrl, "utf8"), {
+    version: pkg.version,
+    date,
+  });
+
+  writeFileSync(changelogUrl, promoted);
+  console.log(`CHANGELOG.md promoted to ${pkg.version} - ${date}`);
+}

--- a/scripts/promote-changelog.test.mjs
+++ b/scripts/promote-changelog.test.mjs
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+
+import { promoteChangelog } from "./promote-changelog.mjs";
+
+const CHANGELOG = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- A new thing
+- A note that mentions Unreleased work in prose
+
+### Fixed
+- A bug
+
+## [1.0.2] - 2026-02-04
+### Changed
+- Updated dependencies
+`;
+
+describe("promoteChangelog", () => {
+  it("replaces the Unreleased heading with the version and date", () => {
+    const result = promoteChangelog(CHANGELOG, {
+      version: "1.0.3",
+      date: "2026-08-09",
+    });
+
+    expect(result).toContain("## [1.0.3] - 2026-08-09");
+    expect(result).not.toContain("## [Unreleased]");
+  });
+
+  it("keeps the entries that were under the Unreleased heading", () => {
+    const result = promoteChangelog(CHANGELOG, {
+      version: "1.0.3",
+      date: "2026-08-09",
+    });
+
+    expect(result).toContain("- A new thing");
+    expect(result).toContain("- A bug");
+    expect(result).toContain("### Added");
+    expect(result).toContain("### Fixed");
+  });
+
+  it("leaves prose mentioning Unreleased untouched", () => {
+    const result = promoteChangelog(CHANGELOG, {
+      version: "1.0.3",
+      date: "2026-08-09",
+    });
+
+    expect(result).toContain("- A note that mentions Unreleased work in prose");
+  });
+
+  it("leaves earlier releases and the preamble untouched", () => {
+    const result = promoteChangelog(CHANGELOG, {
+      version: "1.0.3",
+      date: "2026-08-09",
+    });
+
+    expect(result).toContain("## [1.0.2] - 2026-02-04");
+    expect(result).toContain("- Updated dependencies");
+    expect(result).toContain(
+      "All notable changes to this project will be documented in this file.",
+    );
+    expect(result.startsWith("# Changelog")).toBe(true);
+  });
+
+  it("changes exactly one line", () => {
+    const result = promoteChangelog(CHANGELOG, {
+      version: "1.0.3",
+      date: "2026-08-09",
+    });
+
+    const before = CHANGELOG.split("\n");
+    const after = result.split("\n");
+
+    expect(after).toHaveLength(before.length);
+
+    const changed = before
+      .map((line, i) => (line === after[i] ? null : i))
+      .filter((i) => i !== null);
+
+    expect(changed).toHaveLength(1);
+    expect(before[changed[0]]).toBe("## [Unreleased]");
+    expect(after[changed[0]]).toBe("## [1.0.3] - 2026-08-09");
+  });
+
+  it("throws when there is no Unreleased section to promote", () => {
+    const noUnreleased = `# Changelog
+
+## [1.0.2] - 2026-02-04
+### Changed
+- Updated dependencies
+`;
+
+    expect(() =>
+      promoteChangelog(noUnreleased, { version: "1.0.3", date: "2026-08-09" }),
+    ).toThrow(/no "## \[Unreleased\]" section/);
+  });
+
+  it("throws rather than promoting twice when the version already has an entry", () => {
+    const alreadyReleased = `# Changelog
+
+## [Unreleased]
+### Added
+- Something
+
+## [1.0.3] - 2026-08-09
+### Added
+- Already shipped
+`;
+
+    expect(() =>
+      promoteChangelog(alreadyReleased, {
+        version: "1.0.3",
+        date: "2026-08-09",
+      }),
+    ).toThrow(/already has a "## \[1\.0\.3\]" entry/);
+  });
+
+  it("does not mutate the input string's source changelog content", () => {
+    const original = CHANGELOG;
+    promoteChangelog(CHANGELOG, { version: "1.0.3", date: "2026-08-09" });
+    expect(CHANGELOG).toBe(original);
+  });
+});

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,0 +1,35 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+export function syncServerJson(server, { version, mcpName, packageName }) {
+  if (server.name !== mcpName) {
+    throw new Error(
+      `server.json name "${server.name}" does not match package.json mcpName "${mcpName}". ` +
+        "The server name is permanent and must be corrected by hand.",
+    );
+  }
+
+  return {
+    ...server,
+    version,
+    packages: server.packages.map((entry) =>
+      entry.identifier === packageName ? { ...entry, version } : entry,
+    ),
+  };
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const serverUrl = new URL("../server.json", import.meta.url);
+  const pkg = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  );
+  const server = JSON.parse(readFileSync(serverUrl, "utf8"));
+
+  const updated = syncServerJson(server, {
+    version: pkg.version,
+    mcpName: pkg.mcpName,
+    packageName: pkg.name,
+  });
+
+  writeFileSync(serverUrl, `${JSON.stringify(updated, null, 2)}\n`);
+  console.log(`server.json synced to ${pkg.version}`);
+}

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -13,7 +13,9 @@ export function syncServerJson(server, { version, mcpName, packageName }) {
     ...server,
     version,
     packages: server.packages.map((entry) =>
-      entry.identifier === packageName ? { ...entry, version } : entry,
+      entry.registryType === "npm" && entry.identifier === packageName
+        ? { ...entry, version }
+        : entry,
     ),
   };
 }

--- a/scripts/sync-server-json.mjs
+++ b/scripts/sync-server-json.mjs
@@ -1,4 +1,5 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export function syncServerJson(server, { version, mcpName, packageName }) {
   if (server.name !== mcpName) {
@@ -17,7 +18,10 @@ export function syncServerJson(server, { version, mcpName, packageName }) {
   };
 }
 
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   const serverUrl = new URL("../server.json", import.meta.url);
   const pkg = JSON.parse(
     readFileSync(new URL("../package.json", import.meta.url), "utf8"),

--- a/scripts/sync-server-json.test.mjs
+++ b/scripts/sync-server-json.test.mjs
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+
+import { syncServerJson } from "./sync-server-json.mjs";
+
+const mcpName = "io.github.8ensmith/mcp-open-library";
+const packageName = "mcp-open-library";
+
+function makeServer() {
+  return {
+    $schema: "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    name: mcpName,
+    title: "Open Library",
+    description: "Search books and authors on the Internet Archive's Open Library",
+    version: "1.0.2",
+    websiteUrl: "https://github.com/8enSmith/mcp-open-library#readme",
+    repository: {
+      url: "https://github.com/8enSmith/mcp-open-library",
+      source: "github",
+    },
+    packages: [
+      {
+        registryType: "npm",
+        identifier: packageName,
+        version: "1.0.2",
+        transport: { type: "stdio" },
+      },
+    ],
+  };
+}
+
+describe("syncServerJson", () => {
+  it("updates the top-level version", () => {
+    const result = syncServerJson(makeServer(), {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+    expect(result.version).toBe("1.0.3");
+  });
+
+  it("updates the matching package entry version", () => {
+    const result = syncServerJson(makeServer(), {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+    expect(result.packages[0].version).toBe("1.0.3");
+  });
+
+  it("leaves package entries for other registries untouched", () => {
+    const server = makeServer();
+    server.packages.push({
+      registryType: "nuget",
+      identifier: "Someone.Else",
+      version: "9.9.9",
+      transport: { type: "stdio" },
+    });
+
+    const result = syncServerJson(server, {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+
+    expect(result.packages[1].version).toBe("9.9.9");
+  });
+
+  it("preserves every unrelated field", () => {
+    const server = makeServer();
+    const result = syncServerJson(server, {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+
+    expect(result.$schema).toBe(server.$schema);
+    expect(result.name).toBe(mcpName);
+    expect(result.title).toBe("Open Library");
+    expect(result.description).toBe(server.description);
+    expect(result.websiteUrl).toBe(server.websiteUrl);
+    expect(result.repository).toEqual(server.repository);
+    expect(result.packages[0].registryType).toBe("npm");
+    expect(result.packages[0].transport).toEqual({ type: "stdio" });
+  });
+
+  it("does not mutate the input", () => {
+    const server = makeServer();
+    syncServerJson(server, { version: "1.0.3", mcpName, packageName });
+    expect(server.version).toBe("1.0.2");
+    expect(server.packages[0].version).toBe("1.0.2");
+  });
+
+  it("throws when the server name does not match mcpName", () => {
+    expect(() =>
+      syncServerJson(makeServer(), {
+        version: "1.0.3",
+        mcpName: "io.github.8ensmith/something-else",
+        packageName,
+      }),
+    ).toThrow(/does not match/);
+  });
+});

--- a/scripts/sync-server-json.test.mjs
+++ b/scripts/sync-server-json.test.mjs
@@ -65,6 +65,25 @@ describe("syncServerJson", () => {
     expect(result.packages[1].version).toBe("9.9.9");
   });
 
+  it("leaves a same-identifier entry under another registry untouched", () => {
+    const server = makeServer();
+    server.packages.push({
+      registryType: "nuget",
+      identifier: packageName,
+      version: "9.9.9",
+      transport: { type: "stdio" },
+    });
+
+    const result = syncServerJson(server, {
+      version: "1.0.3",
+      mcpName,
+      packageName,
+    });
+
+    expect(result.packages[0].version).toBe("1.0.3");
+    expect(result.packages[1].version).toBe("9.9.9");
+  });
+
   it("preserves every unrelated field", () => {
     const server = makeServer();
     const result = syncServerJson(server, {

--- a/scripts/sync-server-json.test.mjs
+++ b/scripts/sync-server-json.test.mjs
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import { syncServerJson } from "./sync-server-json.mjs";
 
-const mcpName = "io.github.8ensmith/mcp-open-library";
+const mcpName = "io.github.8enSmith/mcp-open-library";
 const packageName = "mcp-open-library";
 
 function makeServer() {
@@ -94,7 +94,7 @@ describe("syncServerJson", () => {
     expect(() =>
       syncServerJson(makeServer(), {
         version: "1.0.3",
-        mcpName: "io.github.8ensmith/something-else",
+        mcpName: "io.github.8enSmith/something-else",
         packageName,
       }),
     ).toThrow(/does not match/);

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.8ensmith/mcp-open-library",
+  "name": "io.github.8enSmith/mcp-open-library",
   "title": "Open Library",
   "description": "Search books and authors on the Internet Archive's Open Library",
   "version": "1.0.2",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.8ensmith/mcp-open-library",
+  "title": "Open Library",
+  "description": "Search books and authors on the Internet Archive's Open Library",
+  "version": "1.0.2",
+  "websiteUrl": "https://github.com/8enSmith/mcp-open-library#readme",
+  "repository": {
+    "url": "https://github.com/8enSmith/mcp-open-library",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "mcp-open-library",
+      "version": "1.0.2",
+      "transport": { "type": "stdio" }
+    }
+  ]
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { readFileSync } from "node:fs";
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
@@ -49,6 +51,17 @@ describe("OpenLibraryServer", () => {
     // Get the mocked MCP Server instance created by the constructor
     mockMcpServer = (Server as any).mock.results[0].value;
     mockedAxios.create.mockReturnThis(); // Ensure axios.create() returns the mocked instance
+  });
+
+  it("reports the version from package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version: string };
+
+    const [implementation] = (Server as any).mock.calls[0];
+
+    expect(implementation.version).toBe(pkg.version);
+    expect(implementation.name).toBe("open-library-server");
   });
 
   describe("get_book_by_title tool", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -18,6 +20,10 @@ import {
   handleGetBookById,
 } from "./tools/index.js";
 
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
+
 class OpenLibraryServer {
   private server: Server;
   private axiosInstance;
@@ -26,7 +32,7 @@ class OpenLibraryServer {
     this.server = new Server(
       {
         name: "open-library-server",
-        version: "1.0.0",
+        version: pkg.version,
       },
       {
         capabilities: {


### PR DESCRIPTION
Lists this server in the official [MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.8enSmith/mcp-open-library`, and replaces the manual npm release with a tag-triggered pipeline that publishes to npm and the registry together.

The registry stores metadata only — the artifact stays on npm. It proves ownership by fetching the published `package.json` and checking `mcpName` against the name in `server.json`. Since `mcp-open-library@1.0.2` is already on npm without `mcpName`, and npm metadata can't be amended in place, the first listing ships as `1.0.3`.

### The problem worth solving

Adding `server.json` duplicates the release version across five places — `package.json`, `server.json` twice, the git tag, and `src/index.ts` — plus the server identity across two more. Drift either fails the publish or, worse, ships a listing that misrepresents the package. (`src/index.ts` had already drifted: it announced `1.0.0` while the package was at `1.0.2`.)

So `package.json` `version` is the single source of truth, and everything else is derived from it or asserted against it:

- `npm version patch` runs a `version` lifecycle hook that rewrites `server.json` and stages it, producing one commit and tag with everything already consistent.
- `src/index.ts` reads its version from `package.json` at runtime, so it can't drift again.
- The same hook promotes `CHANGELOG.md`'s `## [Unreleased]` heading to the new version and date, and refuses to bump at all if that heading is missing — so a release can't ship undocumented.
- CI re-asserts all five invariants and refuses to publish if anything disagrees.

Releasing is `npm version patch && git push --follow-tags`. The procedure is documented in the README under Development → Releasing, which is new in this PR — previously it existed nowhere a maintainer would look.

### Security

Both npm and the registry authenticate over GitHub OIDC, so **the pipeline stores no secrets** — one `id-token: write` permission covers both. npm publishes via trusted publishing (which also gets us build provenance). The `mcp-publisher` binary is pinned to `v1.8.1` and checksum-verified before it executes, rather than piping `releases/latest` straight into a job that holds publishing rights.

### Reviewer notes

- **`server.json` is committed at `1.0.2`, not the `1.0.3` that ships.** Deliberate — `package.json` stays at `1.0.2` until release time, and committing `1.0.3` here would fail the consistency check on every PR.
- **The namespace is `io.github.8enSmith`, with a capital S**, matching the GitHub login verbatim. The registry builds the grant as `io.github.<owner>/*` with no normalisation, on both the access-token and OIDC paths, and matches it against the raw `server.json` name with a case-sensitive `strings.HasPrefix`. The lowercase form would be rejected at publish. Confirmed against a real token rather than assumed — see below.
- **1,208 of the 1,992 added lines are the design spec and implementation plan** under `docs/superpowers/`. The actual change is 784 lines, 386 of which are tests.
- **This PR is the first exercise of `validate-server-json.yml`**, since it touches `server.json`, `package.json` and `scripts/`.
- CI must use `npm run test:precommit`, never `npm test` — the latter is bare `vitest` in watch mode and would hang the runner.

### Testing

- 24 new unit tests across the three release scripts (full suite: 197 passing, lint clean, build clean).
- `mcp-publisher validate` passes against the committed `server.json`, verified with the real v1.8.1 binary.
- The consistency checker was verified both ways — passing on the current tree, and failing with exit 1 on a mismatched tag.
- The `npm version` hook was exercised end-to-end: bumping to `1.0.3` correctly updated `package.json`, both `server.json` version fields and the changelog heading, staged the derived files, passed the consistency check against tag `v1.0.3`, and was then restored.

### Pre-release setup (both complete)

1. ✅ npm trusted publisher registered — owner `8enSmith`, repo `mcp-open-library`, workflow `publish-mcp.yml`, `Allow npm publish` enabled.
2. ✅ Namespace pre-flight run against the live registry. This is what caught the casing: the granted permission came back as `io.github.8enSmith/*`, not the lowercased form the design originally assumed. Worth noting the failure mode it avoided — `mcp-publisher validate` does not check namespace permissions, so the rejection would have surfaced at the final `publish` step, *after* npm had already published `1.0.3` immutably.

### Follow-up (not in this PR)

`src/index.ts:201` uses a main-module guard that fails open on symlinked paths — and npm's `bin` shims are symlinks. It works today, but the same idiom was hardened in the release scripts here and this one is worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MCP Registry metadata and installation support.
  - Releases tagged with a version can now publish automatically to npm and the MCP Registry.
  - Server metadata and runtime version information stay synchronized with the package version.

- **Bug Fixes**
  - Added release checks for mismatched versions, tags, and changelog entries.
  - Added pull-request validation for server metadata and release consistency.

- **Documentation**
  - Documented registry installation, release procedures, versioning, and validation requirements.
  - Updated the changelog with registry publishing details and the 1.0.2 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->