### PR TITLE
fix: stop advertising the unimplemented resources capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- The server no longer advertises the `resources` capability it never implemented. Clients took the declaration at face value and called `resources/list`, `resources/templates/list` and `resources/read`, each of which returned a JSON-RPC `-32601 Method not found` because no handler was ever registered for them — the MCP Inspector showed a Resources tab and two failed requests on every connect. All three methods sit behind that single capability flag, so removing it stops clients asking
+
 ## [1.1.0] - 2026-08-10
 ### Added
 - Tool: `search_books` - search across titles, authors, subjects, places, people, publishers and ISBNs, with `sort`, `language`, `limit` and `offset`. At least one search criterion is required

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ class OpenLibraryServer {
       },
       {
         capabilities: {
-          resources: {},
           tools: {},
         },
       },


### PR DESCRIPTION
## Problem

The server declared `capabilities.resources` but never registered a handler for it:

```ts
capabilities: {
  resources: {},   // advertised
  tools: {},
},
```

`setupToolHandlers()` registers only `ListToolsRequestSchema` and `CallToolRequestSchema`. There is no `ListResourcesRequestSchema` handler anywhere in `src/`, and the SDK does not synthesise one from the capability declaration — any method without a registered handler falls through to `MethodNotFound`.

Clients took the declaration at face value. Connecting with the MCP Inspector showed a **Resources** tab and two failed requests on every connect:

```json
{ "jsonrpc": "2.0", "id": 2, "error": { "code": -32601, "message": "Method not found" } }
```

## Fix

Remove the declaration. All three resource methods sit behind that single capability flag (`@modelcontextprotocol/sdk` `server/index.js`):

```js
case 'resources/list':
case 'resources/templates/list':
case 'resources/read':
    if (!this._capabilities.resources) { ... }
```

so removing it is what stops clients asking. There is no separate flag for templates to remove alongside it.

This is a declaration fix, not a feature removal — nothing was implemented to remove. If resources are wanted later, the declaration comes back together with handlers for all three methods; a partial implementation would reintroduce -32601 on the two left out.

## Verification

| Check | Result |
| --- | --- |
| `npm run build` | clean; `resources` no longer present in `build/index.js` |
| `npm run test:precommit` | 178 passed, 16 files |
| `npm run lint` | clean |
| Inspector reconnect | `initialize` → `notifications/initialized` → `tools/list`, all OK — no resource probes, no errors |
| Inspector nav | now **Servers \| Tools**; Resources tab gone |
| Tools tab | all 7 tools list correctly |

No test change was needed — `src/index.test.ts` never asserted on capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The server no longer advertises unsupported resource functionality, preventing clients from attempting unavailable resource requests.
  * Tool functionality remains available as before.

* **Documentation**
  * Added an unreleased changelog entry describing the compatibility improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->